### PR TITLE
Update Campaigns.php

### DIFF
--- a/MailWizzApi/Endpoint/Campaigns.php
+++ b/MailWizzApi/Endpoint/Campaigns.php
@@ -110,6 +110,10 @@ class MailWizzApi_Endpoint_Campaigns extends MailWizzApi_Base
             $data['template']['archive'] = base64_encode($data['template']['archive']);
         }
         
+        if (isset($data['template']['plain_text'])) {
+            $data['template']['plain_text'] = base64_encode($data['template']['plain_text']);
+        }
+        
         $client = new MailWizzApi_Http_Client(array(
             'method'        => MailWizzApi_Http_Client::METHOD_PUT,
             'url'           => $this->config->getApiUrl(sprintf('campaigns/%s', $campaignUid)),

--- a/MailWizzApi/Endpoint/Campaigns.php
+++ b/MailWizzApi/Endpoint/Campaigns.php
@@ -78,6 +78,10 @@ class MailWizzApi_Endpoint_Campaigns extends MailWizzApi_Base
             $data['template']['archive'] = base64_encode($data['template']['archive']);
         }
         
+        if (isset($data['template']['plain_text'])) {
+            $data['template']['plain_text'] = base64_encode($data['template']['plain_text']);
+        }
+        
         $client = new MailWizzApi_Http_Client(array(
             'method'        => MailWizzApi_Http_Client::METHOD_POST,
             'url'           => $this->config->getApiUrl('campaigns'),


### PR DESCRIPTION
When using the create and update methods of the campaigns endpoint, the plain text content must be base64 encoded the same way as the html content, otherwise the HTTP request breaks and the API returns an "Invalid API request signature." error.

The mailwizz app expects the plain text content to be encoded ( see mailwizz/apps/api/controllers/campaigns.php line 236 ).
