### PR TITLE
Update subscriber by email method added, some example additions done.

### DIFF
--- a/MailWizzApi/Endpoint/ListSubscribers.php
+++ b/MailWizzApi/Endpoint/ListSubscribers.php
@@ -121,6 +121,37 @@ class MailWizzApi_Endpoint_ListSubscribers extends MailWizzApi_Base
     }
 
     /**
+     * Update existing subscriber by email address
+     *
+     * @param string $listUid
+     * @param string emailAddress
+     * @param array $data
+     * @return MailWizzApi_Http_Response
+     */
+    public function updateByEmail($listUid, $emailAddress, array $data)
+    {
+        $response = $this->emailSearch($listUid, $emailAddress);
+
+        // the request failed.
+        if ($response->isCurlError) {
+            return $response;
+        }
+
+        $bodyData = $response->body->itemAt('data');
+
+        // subscriber not found.
+        if ($response->isError && $response->httpCode == 404) {
+            return $response;
+        }
+
+        if (empty($bodyData['subscriber_uid'])) {
+            return $response;
+        }
+
+        return $this->update($listUid, $bodyData['subscriber_uid'], $data);
+    }
+
+    /**
      * Unsubscribe existing subscriber from given list
      *
      * @param string $listUid

--- a/examples/list_subscribers.php
+++ b/examples/list_subscribers.php
@@ -119,6 +119,22 @@ $response = $endpoint->update('LIST-UNIQUE-ID', 'SUBSCRIBER-UNIQUE-ID', array(
 echo '<hr />';
 echo '<pre>';
 print_r($response->body);
+echo '</pre>';
+
+/*===================================================================================*/
+
+// UPDATE EXISTING SUBSCRIBER BY EMAIL
+$response = $endpoint->updateByEmail('LIST-UNIQUE-ID', 'john@doe.com', array(
+    'EMAIL'    => 'john.doe@doe.com',
+    'FNAME'    => 'John',
+    'LNAME'    => 'Doe Updated'
+));
+
+// DISPLAY RESPONSE
+echo '<hr />';
+echo '<pre>';
+print_r($response->body);
+echo '</pre>';
 
 /*===================================================================================*/
 
@@ -153,6 +169,17 @@ $response = $endpoint->unsubscribeByEmail('LIST-UNIQUE-ID', 'john@doe.com');
 echo '<hr /><pre>';
 print_r($response->body);
 echo '</pre>';
+/*===================================================================================*/
+
+
+// UNSUBSCRIBE existing subscriber from all lists, no email is sent, unsubscribe is silent
+$response = $endpoint->unsubscribeByEmailFromAllLists('john@doe.com');
+
+// DISPLAY RESPONSE
+echo '<hr /><pre>';
+print_r($response->body);
+echo '</pre>';
+
 /*===================================================================================*/
 
 // DELETE SUBSCRIBER, no email is sent, delete is silent


### PR DESCRIPTION
Hello,

We're using Mailwizz, and loving it so far! We're also using this very PHP client. However, we had a feature missing. It's a way to update a user's preferences by email method. By checking the source code, I saw it'd be fairly easy to implement this. So this is my humble attempt to implement a `updateByEmail` method. Also, the example PHP file was missing a `unsubscribeByEmailFromAllLists` example, so I've added that.

I hope this is considered for merging.

Thanks again for maintaining the project!